### PR TITLE
Verify via console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ output/
 
 # Secret files
 .etherscanKey
+.governor
 .infuraKey
 .mythxKey
 .secret

--- a/environments/3_governance.ts
+++ b/environments/3_governance.ts
@@ -17,8 +17,7 @@ import { Wand } from '../typechain/Wand'
  */
 
 const protocol = jsonToMap(fs.readFileSync('./output/protocol.json', 'utf8')) as Map<string, string>;
-const bruce = '0x1Bd3Abb6ef058408734EA01cA81D325039cd7bcA'
-const vlad = '0x1053aC28154E4aFb3B599e69f6B72b2F4293d00A'
+const governor = fs.readFileSync('.governor', 'utf8') as string
 
 console.time("Governance set in");
 
@@ -28,9 +27,6 @@ console.time("Governance set in");
     const ladle = await ethers.getContractAt('Ladle', protocol.get('ladle') as string, ownerAcc) as unknown as Ladle
     const witch = await ethers.getContractAt('Witch', protocol.get('witch') as string, ownerAcc) as unknown as Witch
     const wand = await ethers.getContractAt('Wand', protocol.get('wand') as string, ownerAcc) as unknown as Wand
-
-    // const governor = await ownerAcc.getAddress()
-    const governor = vlad
 
     await cauldron.grantRoles(
         [

--- a/environments/config.ts
+++ b/environments/config.ts
@@ -5,21 +5,21 @@ import { stringToBytes6 } from '../shared/helpers'
 export const TST = stringToBytes6('TST')
 
 // Assets to add to the protocol. A Join will be deployed for each one.
-export const assetIds: string[] = [DAI, USDC/*, ETH, TST, WBTC*/]
+export const assetIds: string[] = [DAI, USDC, ETH, TST, WBTC]
 
 // Assets to make into underlyings. The assets must exist, as well as rate and chi oracle sources.
-export const baseIds: string[] = [DAI/*, USDC*/]
+export const baseIds: string[] = [DAI, USDC]
 
 // Assets to make into collaterals, as [underlying, collateral]. The underlying and collateral assets must exist, as well as spot oracle sources for each pair.
 export const ilkIds: Array<[string, string]> = [
     [DAI, USDC],
-    /*[DAI, ETH],
+    [DAI, ETH],
     [DAI, TST],
     [DAI, WBTC],
     [USDC, DAI],
     [USDC, ETH],
     [USDC, TST],
-    [USDC, WBTC],*/
+    [USDC, WBTC],
 ]
 
 // Series to deploy. A FYToken and Pool will be deployed for each one. The underlying assets must exist and have been added as bases. The collaterals accepted must exist and have been added as collateral for the fyToken underlying asset.


### PR DESCRIPTION
Instead of verifying via hardhat, which results in a mess, we just print the verification command.

You can just capture the logs as you deploy, and copy&paste the verification commands in the console, so they happen one at a time.