### PR TITLE
ops: grant developer role to 0xC7aE076086623ecEA2450e364C838916a043F9a8

### DIFF
--- a/scripts/operations/governance/grantDeveloper.ts
+++ b/scripts/operations/governance/grantDeveloper.ts
@@ -6,6 +6,7 @@
  */
 
 import { ethers } from 'hardhat'
+import * as hre from 'hardhat'
 import * as fs from 'fs'
 import { id } from '@yield-protocol/utils-v2'
 import { jsonToMap } from '../../../shared/helpers'
@@ -15,7 +16,13 @@ import { EmergencyBrake } from '../../../typechain/EmergencyBrake'
 
 ;(async () => {
   const newDeveloper = '0xC7aE076086623ecEA2450e364C838916a043F9a8'
-  const [ownerAcc] = await ethers.getSigners()
+  
+  await hre.network.provider.request({
+    method: "hardhat_impersonateAccount",
+    params: ["0xA072f81Fea73Ca932aB2B5Eda31Fa29306D58708"],
+  });
+  const ownerAcc = await ethers.getSigner("0xA072f81Fea73Ca932aB2B5Eda31Fa29306D58708")
+  // const [ownerAcc] = await ethers.getSigners()
   const governance = jsonToMap(fs.readFileSync('./addresses/governance.json', 'utf8')) as Map<string, string>
 
   // Contract instantiation
@@ -53,13 +60,19 @@ import { EmergencyBrake } from '../../../typechain/EmergencyBrake'
   // Propose, approve, execute
   const txHash = await timelock.hash(proposal)
   console.log(`Proposal: ${txHash}`)
+  // Comment out sections below to propose, approve (impersonating multisig) or execute
   if ((await timelock.proposals(txHash)).state === 0) {
     await timelock.propose(proposal)
     while ((await timelock.proposals(txHash)).state < 1) {}
     console.log(`Proposed ${txHash}`)
   }
-  /* if ((await timelock.proposals(txHash)).state === 1) {
-    await timelock.approve(txHash)
+  if ((await timelock.proposals(txHash)).state === 1) {
+    await hre.network.provider.request({
+      method: "hardhat_impersonateAccount",
+      params: ["0xd659565b84BcfcB23B02ee13E46CB51429F4558A"],
+    });
+    const multisigAcc = await ethers.getSigner("0xd659565b84BcfcB23B02ee13E46CB51429F4558A")
+    await timelock.connect(multisigAcc).approve(txHash)
     while ((await timelock.proposals(txHash)).state < 2) {}
     console.log(`Approved ${txHash}`)
   }
@@ -67,5 +80,5 @@ import { EmergencyBrake } from '../../../typechain/EmergencyBrake'
     await timelock.execute(proposal)
     while ((await timelock.proposals(txHash)).state > 0) {}
     console.log(`Executed ${txHash}`)
-  } */
+  }
 })()


### PR DESCRIPTION
**Urgent**
This PR is urgent because the only account with a developer role currently is the deployer account.

**Purpose of this mainnet transaction**
Granting developer role to 0xC7aE076086623ecEA2450e364C838916a043F9a8

**Code to be run**
[grantDeveloper.ts](https://github.com/yieldprotocol/environments-v2/blob/b6a6a761b713bd933949befb86f2c6bb57fc0369/scripts/operations/governance/grantDeveloper.ts)

**Input data**
`const newDeveloper = '0xC7aE076086623ecEA2450e364C838916a043F9a8'`

**Fork test output**
```
New developer 0xC7aE076086623ecEA2450e364C838916a043F9a8
Proposal: 0xc65eaef94ceb935272146ea664bc2a2fd058f5ea15d1693124e24ce631addc0b
Proposed 0xc65eaef94ceb935272146ea664bc2a2fd058f5ea15d1693124e24ce631addc0b
Approved 0xc65eaef94ceb935272146ea664bc2a2fd058f5ea15d1693124e24ce631addc0b
Executed 0xc65eaef94ceb935272146ea664bc2a2fd058f5ea15d1693124e24ce631addc0b
```

**Verification**
For now, we will do a manual verification of the permissions having been given. In the future, changes like this will include a test file to be run in a mainnet fork with a more robust verification

Either run the following assertions from a script, or their equivalents in Etherscan
await timelock.hasRole('0xca02753a', '0xC7aE076086623ecEA2450e364C838916a043F9a8') == true
await timelock.hasRole('0x013a652d', '0xC7aE076086623ecEA2450e364C838916a043F9a8') == true
await timelock.hasRole('0xbaae8abf', '0xC7aE076086623ecEA2450e364C838916a043F9a8') == true
await timelock.hasRole('0xf9a28e8b', '0xC7aE076086623ecEA2450e364C838916a043F9a8') == true
await cloak.hasRole('0xe751f271', '0xC7aE076086623ecEA2450e364C838916a043F9a8') == true

**Execution time**
As soon as possible after approval