### PR TITLE
feat/rescue

### DIFF
--- a/contracts/dsproxy/DsProxy.sol
+++ b/contracts/dsproxy/DsProxy.sol
@@ -1,0 +1,220 @@
+/**
+ *Submitted for verification at Etherscan.io on 2018-09-06
+*/
+
+// proxy.sol - execute actions atomically through the proxy's identity
+
+// Copyright (C) 2017  DappHub, LLC
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.4.23;
+
+contract DSAuthority {
+    function canCall(
+        address src, address dst, bytes4 sig
+    ) public view returns (bool);
+}
+
+contract DSAuthEvents {
+    event LogSetAuthority (address indexed authority);
+    event LogSetOwner     (address indexed owner);
+}
+
+contract DSAuth is DSAuthEvents {
+    DSAuthority  public  authority;
+    address      public  owner;
+
+    constructor() public {
+        owner = msg.sender;
+        emit LogSetOwner(msg.sender);
+    }
+
+    function setOwner(address owner_)
+        public
+        auth
+    {
+        owner = owner_;
+        emit LogSetOwner(owner);
+    }
+
+    function setAuthority(DSAuthority authority_)
+        public
+        auth
+    {
+        authority = authority_;
+        emit LogSetAuthority(authority);
+    }
+
+    modifier auth {
+        require(isAuthorized(msg.sender, msg.sig));
+        _;
+    }
+
+    function isAuthorized(address src, bytes4 sig) internal view returns (bool) {
+        if (src == address(this)) {
+            return true;
+        } else if (src == owner) {
+            return true;
+        } else if (authority == DSAuthority(0)) {
+            return false;
+        } else {
+            return authority.canCall(src, this, sig);
+        }
+    }
+}
+
+contract DSNote {
+    event LogNote(
+        bytes4   indexed  sig,
+        address  indexed  guy,
+        bytes32  indexed  foo,
+        bytes32  indexed  bar,
+        uint              wad,
+        bytes             fax
+    ) anonymous;
+
+    modifier note {
+        bytes32 foo;
+        bytes32 bar;
+
+        assembly {
+            foo := calldataload(4)
+            bar := calldataload(36)
+        }
+
+        emit LogNote(msg.sig, msg.sender, foo, bar, msg.value, msg.data);
+
+        _;
+    }
+}
+
+// DSProxy
+// Allows code execution using a persistant identity This can be very
+// useful to execute a sequence of atomic actions. Since the owner of
+// the proxy can be changed, this allows for dynamic ownership models
+// i.e. a multisig
+contract DSProxy is DSAuth, DSNote {
+    DSProxyCache public cache;  // global cache for contracts
+
+    constructor(address _cacheAddr) public {
+        require(setCache(_cacheAddr));
+    }
+
+    function() public payable {
+    }
+
+    // use the proxy to execute calldata _data on contract _code
+    function execute(bytes _code, bytes _data)
+        public
+        payable
+        returns (address target, bytes32 response)
+    {
+        target = cache.read(_code);
+        if (target == 0x0) {
+            // deploy contract & store its address in cache
+            target = cache.write(_code);
+        }
+
+        response = execute(target, _data);
+    }
+
+    function execute(address _target, bytes _data)
+        public
+        auth
+        note
+        payable
+        returns (bytes32 response)
+    {
+        require(_target != 0x0);
+
+        // call contract in current context
+        assembly {
+            let succeeded := delegatecall(sub(gas, 5000), _target, add(_data, 0x20), mload(_data), 0, 32)
+            response := mload(0)      // load delegatecall output
+            switch iszero(succeeded)
+            case 1 {
+                // throw if delegatecall failed
+                revert(0, 0)
+            }
+        }
+    }
+
+    //set new cache
+    function setCache(address _cacheAddr)
+        public
+        auth
+        note
+        returns (bool)
+    {
+        require(_cacheAddr != 0x0);        // invalid cache address
+        cache = DSProxyCache(_cacheAddr);  // overwrite cache
+        return true;
+    }
+}
+
+// DSProxyFactory
+// This factory deploys new proxy instances through build()
+// Deployed proxy addresses are logged
+contract DSProxyFactory {
+    event Created(address indexed sender, address indexed owner, address proxy, address cache);
+    mapping(address=>bool) public isProxy;
+    DSProxyCache public cache = new DSProxyCache();
+
+    // deploys a new proxy instance
+    // sets owner of proxy to caller
+    function build() public returns (DSProxy proxy) {
+        proxy = build(msg.sender);
+    }
+
+    // deploys a new proxy instance
+    // sets custom owner of proxy
+    function build(address owner) public returns (DSProxy proxy) {
+        proxy = new DSProxy(cache);
+        emit Created(msg.sender, owner, address(proxy), address(cache));
+        proxy.setOwner(owner);
+        isProxy[proxy] = true;
+    }
+}
+
+// DSProxyCache
+// This global cache stores addresses of contracts previously deployed
+// by a proxy. This saves gas from repeat deployment of the same
+// contracts and eliminates blockchain bloat.
+
+// By default, all proxies deployed from the same factory store
+// contracts in the same cache. The cache a proxy instance uses can be
+// changed.  The cache uses the sha3 hash of a contract's bytecode to
+// lookup the address
+contract DSProxyCache {
+    mapping(bytes32 => address) cache;
+
+    function read(bytes _code) public view returns (address) {
+        bytes32 hash = keccak256(_code);
+        return cache[hash];
+    }
+
+    function write(bytes _code) public returns (address target) {
+        assembly {
+            target := create(0, add(_code, 0x20), mload(_code))
+            switch iszero(extcodesize(target))
+            case 1 {
+                // throw if contract failed to deploy
+                revert(0, 0)
+            }
+        }
+        bytes32 hash = keccak256(_code);
+        cache[hash] = target;
+    }
+}

--- a/contracts/dsproxy/Transfer.sol
+++ b/contracts/dsproxy/Transfer.sol
@@ -1,0 +1,9 @@
+pragma solidity 0.8.6;
+
+contract Transfer {
+    function transferAllEth(address to) external {
+        uint256 value = address(this).balance;
+        (bool success, bytes memory data) = to.call{value: value}(new bytes(0));
+        require(success, "Transfer failed");
+    }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -138,13 +138,20 @@ if (!etherscanKey) {
 
 module.exports = {
   solidity: {
-    version: '0.8.6',
     settings: {
       optimizer: {
         enabled: true,
         runs: 1000,
       }
-    }
+    },
+    compilers: [
+      {
+        version: "0.8.6",
+      },
+      {
+        version: "0.4.23",
+      },
+    ],
   },
   abiExporter: {
     path: './abis',

--- a/scripts/whitehat.ts
+++ b/scripts/whitehat.ts
@@ -1,0 +1,52 @@
+// impersonate dude
+// dsproxy = get dsproxy ctrct
+// do an execute to the WETH9 address, converting everthing
+// do an exectute to our ladle -- exitWeth
+import { ethers, waffle } from 'hardhat'
+import * as hre from 'hardhat'
+import * as fs from 'fs'
+import { getOriginalChainId, getOwnerOrImpersonate, jsonToMap } from '../../../shared/helpers'
+import { readFileSync } from 'fs'
+import { DSProxy, Transfer } from '../../../typechain'
+import TransferArtifact from '../../../artifacts/contracts/dsproxy/Transfer.sol/Transfer.json'
+const { deployContract } = waffle
+
+/**
+ * @dev This script gives developer privileges to an account.
+ */
+;(async () => {
+  const proxyOwner: string = '0xd1d6e624f13bbe3d59e6cd43d7408a7c51c8c033'
+  const rescueeAddress: string = '0x5eea118e75f247014c6d0e990f02a0c254edc852'
+  const dsproxyAddress: string = '0x519125ED7409c4b8b8352908ca841183Dfe0A5b6'
+  const chainId = await getOriginalChainId()
+  if (chainId !== 1) throw 'This is a mainnet operation'
+  const protocol = jsonToMap(fs.readFileSync('./addresses/mainnet/protocol.json', 'utf8')) as Map<string, string>
+
+  await hre.network.provider.request({
+    method: 'hardhat_impersonateAccount',
+    params: [proxyOwner],
+  })
+  await hre.network.provider.request({
+    method: 'hardhat_setBalance',
+    params: [proxyOwner, '0x1000000000000000000000'],
+  })
+
+  const proxyOwnerAcc = await ethers.getSigner(proxyOwner)
+
+  const dsproxy = (await ethers.getContractAt('DSProxy', dsproxyAddress, proxyOwnerAcc)) as DSProxy
+
+  const transfer = (await deployContract(proxyOwnerAcc, TransferArtifact)) as Transfer
+  console.log(`Transfer deployed at ${transfer.address}`)
+  // const transferAddress = '0x9B41aDE83e10e7d0A190f419Aaf9dbdD9091839d'
+  // const transfer = (await ethers.getContractAt('Transfer', transferAddress, proxyOwnerAcc)) as Transfer
+
+  const provider = ethers.getDefaultProvider('http://127.0.0.1:8545/)')
+  let rescueeBalance = await provider.getBalance(rescueeAddress)
+  console.log('Rescuee current eth balance:', ethers.utils.formatEther(rescueeBalance))
+
+  console.log("Using DSProxy.execute to call Transfer.transferAllEth")
+  const data = transfer.interface.encodeFunctionData('transferAllEth', [rescueeAddress])
+  await dsproxy['execute(address,bytes)'](transfer.address, data)
+  rescueeBalance = await provider.getBalance(rescueeAddress)
+  console.log('Rescuee current eth balance:', ethers.utils.formatEther(rescueeBalance))
+})()


### PR DESCRIPTION
This is an exercise to try and rescue 20 Eth for one of our users that was inadvertantly sent to a DS-Proxy contract.  Fortunately the user owns the proxy so the solution was to use that contract's `execute` function (which uses `delegatecall`) to call another contracts function to transfer the Eth.

The hardest part was to find an existing deployed contract that had an external function I could use to send the Eth.   I went through all of the Yield contracts and the closest I found was `Ladle.exitEther` function but in order to use that I would have to wrap the ether into WETH first.  I could not figure out how to wrap the ether using the WETH contract because the `WETH.deposit` function is payable and needs to be called along with sending ether which I can't do obviously with delegatecall... I also looked in the wild for an existing contract I could use, but after going down a few rabbit holes (like looking at some Composable Finance contracts) I gave up looking.

So the first step in this solution was to deploy this `Transfer` contract for 236,954 gas:
```
// Note: The bytecode of this contract could be reduced with some refactor, but ideally I'd prefer to use an existing contract
contract Transfer {
    function transferAllEth(address to) external {
        uint256 value = address(this).balance;
        (bool success, bytes memory data) = to.call{value: value}(new bytes(0));
        require(success, "Transfer failed");
    }
}
```

From there, I had to generate the data for the `execute` call and then just make the call:
```
  const data = transfer.interface.encodeFunctionData('transferAllEth', [rescueeAddress])
  await dsproxy['execute(address,bytes)'](transfer.address, data)
```

Here's my output:

```
$ npx hardhat run --network localhost ./scripts/whitehat.ts
No need to generate any newer typings.
ChainId: 1
Transfer deployed at 0x9B41aDE83e10e7d0A190f419Aaf9dbdD9091839d
Rescuee current eth balance: 73.166555534671032225
Using DSProxy.execute to call Transfer.transferAllEth
Rescuee current eth balance: 93.316555534671032225
```

If I had more time I am pretty sure I could find a function on an existing contract out there somewhere that I could use instead of deploying a new contract.

The reason I put the pr in this repo is because I have been working in this repo and wanted to leverage some of the existing helper functions and setup.