### PR TITLE
feat: set dust in arbitrum to $50

### DIFF
--- a/scripts/governance/newEnvironment/arbitrum/newEnvironment.arb_rinkeby.config.ts
+++ b/scripts/governance/newEnvironment/arbitrum/newEnvironment.arb_rinkeby.config.ts
@@ -60,19 +60,19 @@ export const bases: Array<[string, string]> = [
 
 // Input data: baseId, ilkId, oracle name, ratio (1000000 == 100%), line, dust, dec
 export const chainlinkDebtLimits: Array<[string, string, number, number, number, number]> = [
-  [DAI,  ETH,  1400000,  1000000,  100, 18],
-  [DAI,  DAI,  1000000, 10000000, 0,   18], // Constant 1, no dust
-  [DAI,  USDC, 1330000,  100000,   100, 18], // Via ETH
-  [USDC, ETH,  1400000,  5000000,  100, 6],
-  [USDC, DAI,  1330000,  100000,   100, 6], // Via ETH
-  [USDC, USDC, 1000000, 10000000, 0,   6], // Constant 1, no dust
+  [DAI,  ETH,  1400000, 1000000,  50, 18],
+  [DAI,  DAI,  1000000, 10000000, 0,  18], // Constant 1, no dust
+  [DAI,  USDC, 1330000, 1000000,  50, 18], // Via ETH
+  [USDC, ETH,  1400000, 5000000,  50, 6],
+  [USDC, DAI,  1330000, 1000000,  50, 6], // Via ETH
+  [USDC, USDC, 1000000, 10000000, 0,  6], // Constant 1, no dust
 ]
 
 // Input data: ilkId, duration, initialOffer, auctionLine, auctionDust, dec
 export const chainlinkAuctionLimits: Array<[string, number, number, number, number, number]> = [
-  [ETH,  3600, 714000,  2000000,  10000, 12],
-  [DAI,  3600, 1000000, 10000000, 5000,  18],
-  [USDC, 3600, 751000,  100000,   5000,  6],
+  [ETH,  3600, 714000,  2000000,  2000, 12],
+  [DAI,  3600, 1000000, 10000000, 50,   18],
+  [USDC, 3600, 751000,  100000,   50,   6],
 ]
 
 // seriesId, underlyingId, chiOracleAddress, joinAddress, maturity, name, symbol


### PR DESCRIPTION
Setting `dust` in Arbitrum to about $50, in the basis that gas prices are about 100 cheaper than in mainnet, while transactions take the same gas units.