### PR TITLE
Liquidator regression tests: refactoring, Arbitrum test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,9 @@ test/env:
 
 build/liquidator:
 	cd modules/liquidator && \
-	yarn && yarn build
+	yarn && yarn build && yarn run hardhat export-abi && \
+	npm run buildRouter && \
+	cargo build
 
 clean/liquidator:
 	cd modules/liquidator && \
@@ -25,13 +27,6 @@ _regression_tests := $(patsubst regression_tests/test_%.ts,regression.%,$(wildca
 
 regression.%:
 	npx hardhat test regression_tests/test_$*.ts
-
-regression.flashLiquidator:
-	pushd modules/liquidator && \
-	npm run buildRouter && \
-	popd && \
-	npx hardhat test regression_tests/test_flashLiquidator.ts
-
 
 build: build/env build/liquidator
 clean: clean/env clean/liquidator

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -84,7 +84,8 @@ module.exports = {
   networks: {
     hardhat: {
       accounts,
-      chainId: 31337
+      chainId: 31337,
+      blockGasLimit: 300_000_000
     },
     localhost: {
       chainId: 31337,

--- a/modules/liquidator/hardhat.config.ts
+++ b/modules/liquidator/hardhat.config.ts
@@ -13,8 +13,6 @@ import 'hardhat-gas-reporter'
 import 'solidity-coverage'
 import 'hardhat-deploy'
 
-import { task } from 'hardhat/config'
-
 // import 'hardhat-dapptools'
 
 

--- a/modules/liquidator/package.json
+++ b/modules/liquidator/package.json
@@ -44,7 +44,7 @@
     "ethereum-waffle": "^3.2.2",
     "ethers": "^5.1.3",
     "hardhat": "^2.6.0",
-    "hardhat-abi-exporter": "^2.0.3",
+    "hardhat-abi-exporter": "^2.8.0",
     "hardhat-contract-sizer": "^2.0.3",
     "hardhat-deploy": "^0.9.14",
     "hardhat-gas-reporter": "^1.0.3",

--- a/modules/liquidator/scripts/router.ts
+++ b/modules/liquidator/scripts/router.ts
@@ -62,13 +62,9 @@ async function main() {
     logger.setSettings({ suppressStdOutput: true })
   }
 
-  const chain_id = args.chain_id == 31337 ? 1 : args.chain_id // pretend hardhat is mainnet
+  const chain_id = args.chain_id;
   const provider = new providers.JsonRpcProvider(args.rpc_url)
   const router = new AlphaRouter({ chainId: chain_id, provider })
-
-  // logger.info("token in decimals: ", );
-  // logger.info("token out decimals: ", await getDecimals(provider, args.token_out));
-  // return;
 
   const token_in = new Token(chain_id, args.token_in, await getDecimals(provider, args.token_in), '', '')
 

--- a/modules/liquidator/yarn.lock
+++ b/modules/liquidator/yarn.lock
@@ -2492,7 +2492,7 @@ __metadata:
     ethereum-waffle: ^3.2.2
     ethers: ^5.1.3
     hardhat: ^2.6.0
-    hardhat-abi-exporter: ^2.0.3
+    hardhat-abi-exporter: ^2.8.0
     hardhat-contract-sizer: ^2.0.3
     hardhat-deploy: ^0.9.14
     hardhat-gas-reporter: ^1.0.3
@@ -2719,7 +2719,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-colors@npm:^4.1.1":
+"ansi-colors@npm:^4.1.0, ansi-colors@npm:^4.1.1":
   version: 4.1.1
   resolution: "ansi-colors@npm:4.1.1"
   checksum: 138d04a51076cb085da0a7e2d000c5c0bb09f6e772ed5c65c53cb118d37f6c5f1637506d7155fb5f330f0abcf6f12fa2e489ac3f8cdab9da393bf1bb4f9a32b0
@@ -5665,6 +5665,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"delete-empty@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "delete-empty@npm:3.0.0"
+  dependencies:
+    ansi-colors: ^4.1.0
+    minimist: ^1.2.0
+    path-starts-with: ^2.0.0
+    rimraf: ^2.6.2
+  bin:
+    delete-empty: bin/cli.js
+  checksum: 1e2b030346683f49b12460b91d7e1793fc61e9aa0be152a1b31317363632e92426be270f8d635b89d3915ae7da753dcfa6e3bd200f62edf21eaa876ef4443fd2
+  languageName: node
+  linkType: hard
+
 "depd@npm:^1.1.2, depd@npm:~1.1.2":
   version: 1.1.2
   resolution: "depd@npm:1.1.2"
@@ -8479,12 +8493,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hardhat-abi-exporter@npm:^2.0.3":
-  version: 2.2.0
-  resolution: "hardhat-abi-exporter@npm:2.2.0"
+"hardhat-abi-exporter@npm:^2.8.0":
+  version: 2.8.0
+  resolution: "hardhat-abi-exporter@npm:2.8.0"
+  dependencies:
+    "@ethersproject/abi": ^5.5.0
+    delete-empty: ^3.0.0
   peerDependencies:
     hardhat: ^2.0.0
-  checksum: 3585e869f1978f6309d3c1b529ce03bf0bbbad3a14713e650c64316bba506b5eacf27d85275bf70e74e24e811a3ac5cff6d81d8ff5e111e71eab3adff7c80eb0
+  checksum: d8657b0d4ed55e1de0a18d8e70b8de38cf1f8c85e4162cdfe499b74d75f17992359c0c621d1b920f5a666eed2bd26c0a63d8c18ba60d1660f49c9fed378afe62
   languageName: node
   linkType: hard
 
@@ -12372,6 +12389,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-starts-with@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "path-starts-with@npm:2.0.0"
+  checksum: c780e5feb53f37a0cc78c446181aac2d1e4554e5693bbc4ad03c99157b9411ade26a3503dcd5b3b8f0fd56d36daa60ce5a8c24d66b54a400c812fe11eb5bcab9
+  languageName: node
+  linkType: hard
+
 "path-to-regexp@npm:0.1.7":
   version: 0.1.7
   resolution: "path-to-regexp@npm:0.1.7"
@@ -13646,7 +13670,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rimraf@npm:2, rimraf@npm:^2.2.8, rimraf@npm:^2.5.2, rimraf@npm:^2.6.3":
+"rimraf@npm:2, rimraf@npm:^2.2.8, rimraf@npm:^2.5.2, rimraf@npm:^2.6.2, rimraf@npm:^2.6.3":
   version: 2.7.1
   resolution: "rimraf@npm:2.7.1"
   dependencies:

--- a/modules/shared/mocks/ArbSysMock.sol
+++ b/modules/shared/mocks/ArbSysMock.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.0;
+
+/**
+Mock Arbitrum's ArbSys precompile (deployed at 0x64)
+
+Useful when forking Arbitrum with hardhat: the fork doesn't have Arbitrum-specific precompiles
+ */
+contract ArbSysMock {
+    /**
+    * @notice Get Arbitrum block number
+    * @return block number as int
+     */ 
+    function arbBlockNumber() external view returns (uint) {
+        return block.number;
+    }
+}

--- a/regression_tests/test_flashLiquidatorArbitrum.ts
+++ b/regression_tests/test_flashLiquidatorArbitrum.ts
@@ -1,0 +1,110 @@
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { ArbSysMock, ArbSysMock__factory, FlashLiquidator, FlashLiquidator__factory } from "../typechain";
+
+import { expect } from "chai";
+import { ethers, network } from "hardhat";
+
+import { Logger } from "tslog";
+
+import { LiquidatorConfig, run_liquidator, TestFixture, testSetUp } from "./utils_liquidator";
+import { hardhat_fork as fork } from "./utils";
+
+const logger: Logger = new Logger();
+
+const g_multicall2 = "0x80c7dd17b01855a6d2347444a0fcc36136a314de";
+const g_witch = "0x08173D0885B00BDD640aaE57D05AbB74cd00d669"
+const g_uni_router_02 = "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45";
+const g_flash_loaner = '0xBA12222222228d8Ba445958a75a0704d566BF2C8'
+const g_port = 8555;
+
+
+async function deploy_flash_liquidator(): Promise<[SignerWithAddress, LiquidatorConfig]> {
+    const [owner] = await ethers.getSigners() as SignerWithAddress[];
+
+    const flFactory = await ethers.getContractFactory("FlashLiquidator") as FlashLiquidator__factory;
+
+
+    const liquidator = await flFactory.deploy(g_witch, g_uni_router_02, g_flash_loaner) as FlashLiquidator;
+    logger.info("Liquidator deployed at: ", liquidator.address);
+    return [owner, new LiquidatorConfig(g_multicall2, liquidator.address, g_witch, g_uni_router_02,
+        network.config.chainId!,
+        g_port)];
+}
+
+describe("flash liquidator", function () {
+    let fixture: TestFixture = new TestFixture();
+    fixture.chain_id = 42161;
+
+    testSetUp(this, g_port, fixture);
+
+    it("liquidates a vaults on Feb-16-2021 (block: 6228926)", async function () {
+        this.timeout(1800e3);
+
+        await fork(6228926, "arb-mainnet");
+        const [_owner, liquidator] = await deploy_flash_liquidator();
+
+        const starting_balance = await _owner.getBalance();
+
+        const vauld_id = "300eac7ff309b16b6b62d028";
+
+        // the vault is not underwater and the bot won't liquidate it
+        // to force the liquidation, we raise the minimum collateralization ratio from 140% to 280%
+        // we need to overwrite Cauldron's storage: mapping (bytes6 => mapping(bytes6 => DataTypes.SpotOracle)) public spotOracles;
+        // Use this Solidity code to compute the storage address:
+        //
+        // bytes6 base_id = hex"303200000000";
+        // bytes6 ilk_id = hex"303000000000";
+        // uint256 slot = 8; (3 slots from Constants; 1 slot from AccessControl; 5th slot in Cauldron)
+        // bytes32 key = keccak256(abi.encodePacked(bytes32(ilk_id),  
+        //     keccak256(abi.encodePacked(bytes32(base_id),  slot))));
+        // bytes memory x = abi.encodePacked(uint256(key));
+        // (details: https://docs.soliditylang.org/en/v0.8.12/internals/layout_in_storage.html#mappings-and-dynamic-arrays)
+        //
+        // original value stored:
+        // ❯❯❯ seth storage --rpc-url=https://arb-mainnet.g.alchemy.com/v2/U-UL75gKAlSVqycCC_vkCvw03r3QwKEd $CAULDRON 0x84e340865ca631ed48733f6aa28877cc399b6b6122b4d50a3045b126446d1e93
+        // 0x000000000000000000155cc030e042468e333fde8e52dd237673d7412045d2ac
+        //
+        // Last 20 bytes is DataTypes.SpotOracle.oracle; 4 bytes before that (155cc0) is the ratio that we want to change
+
+        await network.provider.send("hardhat_setStorageAt", [
+            "0x23cc87FBEBDD67ccE167Fa9Ec6Ad3b7fE3892E30",                         // cauldron
+            "0x84e340865ca631ed48733f6aa28877cc399b6b6122b4d50a3045b126446d1e93", // storage slot
+            "0x0000000000000000002ab98030e042468e333fde8e52dd237673d7412045d2ac", // original value with new ratio
+        ]);
+
+
+        // Since we're running on a hardhat fork, we don't have access to Arbitrum precompiles
+        // Multicall2 contract (https://arbiscan.io/address/0x842eC2c7D803033Edf55E478F461FC547Bc54EB2) needs
+        // them, so we deploy our mock at the precompile address
+        // Details why Multical2 uses the precompile: https://developer.offchainlabs.com/docs/time_in_arbitrum
+        // 
+        const arbSysMockFactory = await ethers.getContractFactory("ArbSysMock") as ArbSysMock__factory;
+        const arbSysMock = await arbSysMockFactory.deploy() as ArbSysMock
+        const arbSysCode = await ethers.provider.getCode(arbSysMock.address);
+
+        expect(await network.provider.send('hardhat_setCode', [
+            '0x0000000000000000000000000000000000000064',
+            arbSysCode
+        ])).to.be.true;
+
+        logger.info("Triggering auction");
+        // do the 1st run: trigger the auction
+        await run_liquidator(fixture, liquidator);
+        logger.info("Liquidating vaults")
+        // 2nd run: liquidate the vault
+        const liquidator_logs = await run_liquidator(fixture, liquidator);
+
+        let bought = 0;
+
+        for (const log_record of liquidator_logs) {
+            if (log_record["level"] == "INFO" && log_record["fields"]["message"] == "Submitted buy order") {
+                bought++;
+            }
+            expect(log_record["level"]).to.not.equal("ERROR"); // no errors allowed
+        }
+        expect(bought).to.be.equal(1)
+
+        const final_balance = await _owner.getBalance();
+        logger.warn("ETH used: ", starting_balance.sub(final_balance).div(1e12).toString(), "uETH")
+    });
+});

--- a/regression_tests/utils.ts
+++ b/regression_tests/utils.ts
@@ -1,5 +1,10 @@
 import { exec as exec_async, ExecException, ExecOptions } from "child_process";
+import { promises as fs } from 'fs';
+import { join } from "path";
 import { promisify } from "util";
+
+import { network as hh_network } from "hardhat";
+
 
 const exec = promisify(exec_async);
 
@@ -21,4 +26,21 @@ export async function execute(command: string,
     } catch (x) {
         return { stdout: (x as any).stdout, stderr: (x as any).stderr, error: x };
     }
+}
+
+export async function hardhat_fork(block_number?: number, network: "eth-mainnet"|"arb-mainnet" = "eth-mainnet") {
+    const alchemy_keys = JSON.parse(await fs.readFile(join(__dirname, "..", '.alchemyKey'), {encoding: "utf-8"}));
+    const alchemy_key = alchemy_keys[network];
+
+    await hh_network.provider.request({
+        method: "hardhat_reset",
+        params: [
+            {
+                forking: {
+                    jsonRpcUrl: alchemy_key,
+                    blockNumber: block_number,
+                },
+            },
+        ],
+    });
 }

--- a/regression_tests/utils_liquidator.ts
+++ b/regression_tests/utils_liquidator.ts
@@ -1,0 +1,124 @@
+import { exec as exec_async } from "child_process";
+import { promises as fs } from 'fs';
+import { tmpdir } from "os";
+import { join } from "path";
+import { createInterface } from "readline";
+import { Readable } from "stream";
+import { promisify } from "util";
+
+import { normalizeHardhatNetworkAccountsConfig } from "hardhat/internal/core/providers/util";
+import { HardhatNetworkAccountsConfig } from "hardhat/types/config";
+import { subtask } from "hardhat/config";
+import { config, network, run } from "hardhat";
+
+
+import { Logger } from "tslog";
+
+const exec = promisify(exec_async);
+const logger: Logger = new Logger();
+
+
+export class LiquidatorConfig {
+    constructor(
+        readonly multicall2: string,
+        readonly liquidator: string,
+        readonly witch: string,
+        readonly swap_router_v2: string,
+        readonly chain_id: number,
+        readonly port: number) { }
+}
+
+export class TestFixture {
+    private_key: string = "";
+    tmp_root: string = "";
+    chain_id: number = -1;
+}
+
+export async function run_liquidator(fixture: TestFixture, config: LiquidatorConfig,
+    base_to_debt_threshold: { [name: string]: string } = {}) {
+
+    const config_path = join(fixture.tmp_root, "config.json")
+    await fs.writeFile(config_path, JSON.stringify({
+        "Witch": config.witch,
+        "Flash": config.liquidator,
+        "Multicall2": config.multicall2,
+        "BaseToDebtThreshold": base_to_debt_threshold,
+        "SwapRouter02": config.swap_router_v2
+    }, undefined, 2))
+
+
+    const private_key_path = join(fixture.tmp_root, "private_key")
+    await fs.writeFile(private_key_path, fixture.private_key)
+    const cmd = `cargo run -- -c ${config_path} -u http://127.0.0.1:${config.port}/ -C ${config.chain_id} \
+        -p ${private_key_path} \
+        --gas-boost 10 \
+        --swap-router-binary build/bin/router \
+        --one-shot \
+        --json-log \
+        --file /dev/null`
+
+    let stdout: string;
+    let stderr: string
+    try {
+        const results = await exec(cmd, {
+            cwd: "modules/liquidator",
+            encoding: "utf-8", env: {
+                "RUST_BACKTRACE": "1",
+                "RUST_LOG": "liquidator,yield_liquidator=debug",
+                ...process.env
+            },
+            maxBuffer: 1024 * 1024 * 10
+        })
+        stdout = results.stdout
+        stderr = results.stderr
+    } catch (x) {
+        stdout = (x as any).stdout;
+        stderr = (x as any).stderr;
+    }
+    await fs.writeFile(join(fixture.tmp_root, "stdout"), stdout)
+    await fs.writeFile(join(fixture.tmp_root, "stderr"), stderr)
+    logger.info("tmp root", fixture.tmp_root)
+
+    const rl = createInterface({
+        input: Readable.from(stdout),
+        crlfDelay: Infinity
+    });
+
+    const ret = new Array<any>();
+    for await (const line of rl) {
+        ret.push(JSON.parse(line));
+    }
+    return ret;
+}
+
+
+export async function testSetUp(self: Mocha.Suite, http_port: number, fixture: TestFixture) {
+    self.beforeAll(async function () {
+        if (fixture.chain_id != -1) {
+            config.networks[network.name].chainId = fixture.chain_id;
+        }
+        const accounts = normalizeHardhatNetworkAccountsConfig(
+            config.networks[network.name].accounts as HardhatNetworkAccountsConfig
+        );
+
+        fixture.private_key = accounts[0].privateKey.slice(2);
+
+        return new Promise((resolve, fail) => {
+            run("node", { silent: true, port: http_port });
+
+            // launch hardhat node so that external processes can access it
+            subtask("node:server-ready", async function (args, _hre, runSuper) {
+                try {
+                    await runSuper(args);
+                    logger.info("node launched");
+                    resolve()
+                } catch {
+                    fail();
+                }
+            })
+        })
+    })
+    self.beforeEach(async function () {
+        fixture.tmp_root = await fs.mkdtemp(join(tmpdir(), "flash_liquidator_test"))
+    })
+}

--- a/tools/vault_info.sh
+++ b/tools/vault_info.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -euo pipefail
+VAULT_ID=$1
+
+function print_asset_info() {
+    ASSET_ID=$1
+    read ADDRESS < <(seth call --rpc-url $RPC_URL $CAULDRON "assets(bytes6)(address)" $ASSET_ID)
+    read DECIMALS < <(seth call --rpc-url $RPC_URL $ADDRESS "decimals()(uint8)")
+    read SYMBOL < <(seth call --rpc-url $RPC_URL $ADDRESS "symbol()(string)")
+    echo -e "\t\tAddress: $ADDRESS"
+    echo -e "\t\tDecimals: $DECIMALS"
+    echo -e "\t\tSymbol: $SYMBOL"
+}
+
+function format_erc20_balance() {
+    INPUT_BALANCE=$1
+    BALANCE=$(awk "BEGIN { print $INPUT_BALANCE / 1e$DECIMALS }")
+}
+
+read -d\$'\1' OWNER SERIES_ID ILK_ID < <(seth call --rpc-url $RPC_URL $CAULDRON "vaults(bytes12)(address,bytes6,bytes6)" $VAULT_ID) || true
+echo "Owner: $OWNER"
+
+echo "Ilk"
+read -d\$'\1' DEBT COLLATERAL < <(seth call --rpc-url $RPC_URL $CAULDRON "balances(bytes12)(uint128,uint128)" $VAULT_ID) || true
+echo -e "\tAsset ID: $ILK_ID"
+print_asset_info $ILK_ID
+format_erc20_balance $COLLATERAL
+echo -e "\tCollateral: $BALANCE"
+
+echo "Series"
+read -d\$'\1' FY_TOKEN BASE_ID MATURITY < <(seth call --rpc-url $RPC_URL $CAULDRON "series(bytes6)(address,bytes6,uint32)" $SERIES_ID) || true
+echo -e "\tID: $SERIES_ID"
+echo -e "\tBase Asset ID: $BASE_ID"
+print_asset_info $BASE_ID
+format_erc20_balance $DEBT
+echo -e "\tDebt: $BALANCE"
+
+
+read -d\$'\1' LEVEL < <(seth call --rpc-url $RPC_URL $CAULDRON "level(bytes12)(int128)" $VAULT_ID) || true
+echo "Level: $LEVEL"
+
+read -d\$'\1' SPOT_ORACLE RATIO < <(seth call --rpc-url $RPC_URL $CAULDRON "spotOracles(bytes6,bytes6)(address,uint32)" $BASE_ID $ILK_ID) || true
+RATIO_PCT=$(awk "BEGIN { print $RATIO / 1e4 }")
+echo "Spot oracle: $SPOT_ORACLE; ratio: $RATIO_PCT%"


### PR DESCRIPTION
* moved router build to 'build' step
* pulled out common functionality to shared files
+ support for tests on arbitrum
+ flashLiquidatorArbitrum regression test
+ ArbSysMock to mock Arbitrum precompiles on the fork
+ tools/vault_info.sh to print vault info:
```
    ❯❯❯ tools/vault_info.sh 0x300eac7ff309b16b6b62d028
    Owner: 0xbC2051303CE1FFC2aC8239a172aAf60b368086bD
    Ilk
            Asset ID: 0x303000000000
                    Address: 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1
                    Decimals: 18
                    Symbol: WETH
            Collateral: 0.0781591
    Series
            ID: 0x303230350000
            Base Asset ID: 0x303200000000
                    Address: 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8
                    Decimals: 6
                    Symbol: USDC
            Debt: 100.28
    Level: 84777723
    Spot oracle: 0x30e042468e333Fde8E52Dd237673D7412045D2AC; ratio: 140%
```