### PR TITLE
liquidator bot: gas bump tweaks; provider resiliency

### DIFF
--- a/modules/liquidator/src/bin/liquidator.rs
+++ b/modules/liquidator/src/bin/liquidator.rs
@@ -165,7 +165,7 @@ async fn run<P: JsonRpcClient + 'static>(opts: Opts, provider: Provider<P>) -> a
 
     let mut gas_escalator = GeometricGasPrice::new();
     gas_escalator.coefficient = 1.12501;
-    gas_escalator.every_secs = 5; // TODO: Make this be 90s
+    gas_escalator.every_secs = 20;
     gas_escalator.max_price = Some(U256::from(5000 * 1e9 as u64)); // 5k gwei
 
     let base_to_debt_threshold: HashMap<BaseIdType, u128> = cfg.base_to_debt_threshold.iter()


### PR DESCRIPTION
 * don't crash if we failed to get block details from provider: retry a couple of times and crash only if all retries failed
We don't want to **ignore** these errors as they could be a symptom of a bigger issue
 * every time we bumped gas for a TX, we didn't update the TX's timestamp -> the next cycle would see the old TX timestamp and decide to re-bump the gas price right away, instead of waiting
 * reduce the aggressiveness of bumping gas: it went up to the max (5k gwei!) after just 3 minutes. It now takes ~10-15mm to go that high