### PR TITLE
liquidator: nuclear retries

### DIFF
--- a/modules/liquidator/Cargo.lock
+++ b/modules/liquidator/Cargo.lock
@@ -2884,6 +2884,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "tryhard"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cd27b84d4410536f50315f5179a49b651c365328bbeff9900b4c65fc3b92fa"
+dependencies = [
+ "futures",
+ "pin-project",
+ "tokio",
+]
+
+[[package]]
 name = "tungstenite"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3221,6 +3232,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "tryhard",
 ]
 
 [[package]]

--- a/modules/liquidator/Cargo.toml
+++ b/modules/liquidator/Cargo.toml
@@ -15,6 +15,7 @@ hex = "0.4.3"
 serde_json = "1.0.57"
 serde_with = "1.10.0"
 tokio = { version = "1.11.0", features = ["full"] }
+tryhard = "0.4.0"
 async-process = "1.3.0"
 ring = "0.16.19"
 


### PR DESCRIPTION
Use `tryhard` crate to do high-level retries on each iteration, plus retries on querying
the filters. Turns out the latter was causing all of the timeouts in production