### PR TITLE
Changed _addIlksToSeries

### DIFF
--- a/contracts/wands/CollateralWandBase.sol
+++ b/contracts/wands/CollateralWandBase.sol
@@ -191,7 +191,7 @@ contract CollateralWandBase is AccessControl {
 
     /// @notice Ilks to accept for series
     /// @param seriesIlks series & ilks to be added
-    function _addIlksToSeries(SeriesIlk[] calldata seriesIlks) internal {
+    function _addIlksToSeries(SeriesIlk[] memory seriesIlks) internal {
         SeriesIlk memory seriesIlk;
         // Add ilks to the series
         for (uint256 index = 0; index < seriesIlks.length; index++) {


### PR DESCRIPTION
Updating _addIlksToSeries in CollateralBaseWand to take in parameters from memory, instead of calldata.

This will allow fCashWand to pass structs (created in memory) into _addIlksToSeries.
https://github.com/yieldprotocol/environments-v2/pull/191#issuecomment-1200126749