### PR TITLE
Load the yield protocol as a single object

### DIFF
--- a/scripts/governance/protocol.ts
+++ b/scripts/governance/protocol.ts
@@ -1,0 +1,47 @@
+import { ethers } from 'hardhat'
+
+import { ASSET_IDS } from '../../shared/constants'
+import { Entity, Permission, Role, Asset, Join, YieldProtocol } from './yieldTypes'
+import { Cauldron__factory, Ladle__factory, Join__factory, IERC20Metadata__factory } from '../../typechain'
+
+/// @dev Populates the protocol object with assets
+export const loadAssets = async (protocol: YieldProtocol): Promise<YieldProtocol> => {
+  let [ownerAcc] = await ethers.getSigners()
+  const cauldron = Cauldron__factory.connect(protocol.cauldron.address, ownerAcc)
+  for (let assetId of ASSET_IDS.values()) {
+    const assetAddress = await cauldron.assets(assetId)
+    if ((await ethers.provider.getCode(assetAddress)) === '0x') throw `Address ${assetAddress} contains no code`
+    const asset = IERC20Metadata__factory.connect(assetAddress, ownerAcc)
+    protocol.assets.set(
+      assetId,
+      new Asset({
+        assetId: assetId,
+        address: assetAddress,
+        name: await asset.name(),
+        symbol: await asset.symbol(),
+        decimals: await asset.decimals(),
+      })
+    )
+  }
+  return protocol
+}
+
+/// @dev Populates the protocol object with joins
+/// @notice The protocol needs to have been populated with assets first
+export const loadJoins = async (protocol: YieldProtocol): Promise<YieldProtocol> => {
+  let [ownerAcc] = await ethers.getSigners()
+  const ladle = Ladle__factory.connect(protocol.ladle.address, ownerAcc)
+  for (let asset of protocol.assets.values()) {
+    const joinAddress = await ladle.joins(asset.assetId)
+    if ((await ethers.provider.getCode(joinAddress)) === '0x')
+      console.warn(`There is no join for asset ${asset.assetId}`)
+    protocol.joins.set(
+      asset.assetId,
+      new Join({
+        asset: asset,
+        address: joinAddress,
+      })
+    )
+  }
+  return protocol
+}

--- a/scripts/governance/yieldTypes.ts
+++ b/scripts/governance/yieldTypes.ts
@@ -14,6 +14,7 @@ export interface Permission {
 
 /// @dev A role is a group of permissions. Developer, Governor, Ladle.
 export interface Role {
+  key: string
   permissions: Permission[]
 }
 
@@ -98,4 +99,21 @@ export interface Auction {
   vaultProportion: BigNumber
   collateralProportion: BigNumber
   max: BigNumber
+}
+
+/// @dev A single-object representation fo the Yield Protocol
+export interface YieldProtocol {
+  cauldron: Singleton
+  ladle: Singleton
+  witch: Singleton
+  assets: Map<string, Asset>
+  bases: Map<string, Base>
+  ilks: Map<string, Map<string, Ilk>>
+  auctions: Map<string, Map<string, Auction>>
+  joins: Map<string, Join>
+  fyTokens: Map<string, FYToken>
+  pools: Map<string, Pool>
+  strategies: Map<string, Strategy>
+  roles: Map<string, Role>
+  accounts: Map<string, Entity>
 }

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -12,6 +12,33 @@ export const MAX256 = BigNumber.from(2).pow(256).sub(1)
 export const THREE_MONTHS: number = 3 * 30 * 24 * 60 * 60
 export const ROOT = '0x00000000'
 
+export const ASSET_IDS: Map<string, string> = new Map([
+  ['DAI', ethers.utils.formatBytes32String('01').slice(0, 14)],
+  ['ETH', ethers.utils.formatBytes32String('00').slice(0, 14)],
+  ['USDC', ethers.utils.formatBytes32String('02').slice(0, 14)],
+  ['WBTC', ethers.utils.formatBytes32String('03').slice(0, 14)],
+  ['WSTETH', ethers.utils.formatBytes32String('04').slice(0, 14)],
+  ['STETH', ethers.utils.formatBytes32String('05').slice(0, 14)],
+  ['LINK', ethers.utils.formatBytes32String('06').slice(0, 14)],
+  ['ENS', ethers.utils.formatBytes32String('07').slice(0, 14)],
+  ['YVDAI', ethers.utils.formatBytes32String('08').slice(0, 14)],
+  ['YVUSDC', ethers.utils.formatBytes32String('09').slice(0, 14)],
+  ['UNI', ethers.utils.formatBytes32String('10').slice(0, 14)],
+  ['MKR', ethers.utils.formatBytes32String('11').slice(0, 14)],
+  ['FDAI2203', ethers.utils.formatBytes32String('12').slice(0, 14)],
+  ['FUSDC2203', ethers.utils.formatBytes32String('13').slice(0, 14)],
+  ['FDAI2206', ethers.utils.formatBytes32String('14').slice(0, 14)],
+  ['FUSDC2206', ethers.utils.formatBytes32String('15').slice(0, 14)],
+  ['FDAI2209', ethers.utils.formatBytes32String('16').slice(0, 14)],
+  ['FUSDC2209', ethers.utils.formatBytes32String('17').slice(0, 14)],
+  ['FRAX', ethers.utils.formatBytes32String('18').slice(0, 14)],
+  ['CVX3CRV', ethers.utils.formatBytes32String('19').slice(0, 14)],
+  ['EWETH', ethers.utils.formatBytes32String('20').slice(0, 14)],
+  ['EDAI', ethers.utils.formatBytes32String('21').slice(0, 14)],
+  ['EUSDC', ethers.utils.formatBytes32String('22').slice(0, 14)],
+  ['FDAI2212', ethers.utils.formatBytes32String('23').slice(0, 14)],
+  ['FUSDC2212', ethers.utils.formatBytes32String('24').slice(0, 14)],
+])
 export const ETH = ethers.utils.formatBytes32String('00').slice(0, 14)
 export const DAI = ethers.utils.formatBytes32String('01').slice(0, 14)
 export const USDC = ethers.utils.formatBytes32String('02').slice(0, 14)
@@ -141,7 +168,3 @@ export const RATE = ethers.utils.formatBytes32String('RATE').slice(0, 14)
 export const G1 = ethers.utils.formatBytes32String('g1')
 export const G2 = ethers.utils.formatBytes32String('g2')
 export const TS = ethers.utils.formatBytes32String('ts')
-
-export const TIMELOCK = 'timelock'
-export const CLOAK = 'cloak'
-export const MULTISIG = 'multisig'


### PR DESCRIPTION
The Yield Protocol can be represented as a single object, navigable to all contracts, accounts and settings.

The goal is to be able to load this object from a chain, possibly starting with just the addresses of the singleton contracts. On loading the protocol verification checks would be added where the input data might lead to mistakes.