### PR TITLE
Move `id` to helpers from yield-utils

### DIFF
--- a/scripts/fragments/assetsAndSeries/orchestrateFYToken.ts
+++ b/scripts/fragments/assetsAndSeries/orchestrateFYToken.ts
@@ -1,8 +1,7 @@
-import { id } from '@yield-protocol/utils-v2'
 import { EmergencyBrake, Timelock, AccessControl__factory, FYToken, Join__factory } from '../../../typechain'
 import { revokeRoot } from '../permissions/revokeRoot'
 import { addAsHostToCloak } from '../cloak/addAsHostToCloak'
-import { getName, indent } from '../../../shared/helpers'
+import { getName, indent, id } from '../../../shared/helpers'
 
 export const orchestrateFYToken = async (
   deployer: string,

--- a/scripts/fragments/assetsAndSeries/orchestrateFlashJoin.ts
+++ b/scripts/fragments/assetsAndSeries/orchestrateFlashJoin.ts
@@ -1,8 +1,7 @@
-import { id } from '@yield-protocol/utils-v2'
 import { EmergencyBrake, Timelock, AccessControl__factory, FlashJoin } from '../../../typechain'
 import { revokeRoot } from '../permissions/revokeRoot'
 import { addAsHostToCloak } from '../cloak/addAsHostToCloak'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 export const orchestrateFlashJoin = async (
   deployer: string,

--- a/scripts/fragments/assetsAndSeries/orchestrateJoin.ts
+++ b/scripts/fragments/assetsAndSeries/orchestrateJoin.ts
@@ -1,8 +1,7 @@
-import { id } from '@yield-protocol/utils-v2'
 import { EmergencyBrake, Timelock, AccessControl__factory, Join } from '../../../typechain'
 import { revokeRoot } from '../permissions/revokeRoot'
 import { addAsHostToCloak } from '../cloak/addAsHostToCloak'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 export const orchestrateJoin = async (
   deployer: string,

--- a/scripts/fragments/cloak/addFYTokenToCloak.ts
+++ b/scripts/fragments/cloak/addFYTokenToCloak.ts
@@ -1,7 +1,6 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
-import { id } from '@yield-protocol/utils-v2'
 import { EmergencyBrake, FYToken__factory, Join__factory } from '../../../typechain'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 export const addFYTokenToCloak = async (
   signerAcc: SignerWithAddress,

--- a/scripts/fragments/cloak/addGiverToCloak.ts
+++ b/scripts/fragments/cloak/addGiverToCloak.ts
@@ -1,6 +1,5 @@
-import { id } from '@yield-protocol/utils-v2'
 import { Cauldron, EmergencyBrake, Giver } from '../../../typechain'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 export const addGiverToCloak = async (
   cloak: EmergencyBrake,

--- a/scripts/fragments/cloak/addLadleToCloak.ts
+++ b/scripts/fragments/cloak/addLadleToCloak.ts
@@ -1,7 +1,6 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
-import { id } from '@yield-protocol/utils-v2'
 import { Cauldron, EmergencyBrake, FYToken__factory, Join__factory, Ladle } from '../../../typechain'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 export const addLadleToCloak = async (
   signerAcc: SignerWithAddress,

--- a/scripts/fragments/cloak/addLeverToCloak.ts
+++ b/scripts/fragments/cloak/addLeverToCloak.ts
@@ -1,6 +1,5 @@
-import { id } from '@yield-protocol/utils-v2'
 import { EmergencyBrake, Giver } from '../../../typechain'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 export const addLeverToCloak = async (
   cloak: EmergencyBrake,

--- a/scripts/fragments/cloak/addWitchToCloak.ts
+++ b/scripts/fragments/cloak/addWitchToCloak.ts
@@ -1,7 +1,6 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
-import { id } from '@yield-protocol/utils-v2'
 import { Cauldron, EmergencyBrake, FYToken__factory, Join__factory, Witch } from '../../../typechain'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 export const addWitchToCloak = async (
   signerAcc: SignerWithAddress,

--- a/scripts/fragments/core/orchestrateCauldron.ts
+++ b/scripts/fragments/core/orchestrateCauldron.ts
@@ -1,8 +1,7 @@
-import { id } from '@yield-protocol/utils-v2'
 import { ROOT } from '../../../shared/constants'
 import { Cauldron, OldEmergencyBrake, Timelock } from '../../../typechain'
 import { revokeRoot } from '../permissions/revokeRoot'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 /**
  * @dev This script orchestrates the Cauldron

--- a/scripts/fragments/core/orchestrateLadle.ts
+++ b/scripts/fragments/core/orchestrateLadle.ts
@@ -1,8 +1,7 @@
-import { id } from '@yield-protocol/utils-v2'
 import { ROOT } from '../../../shared/constants'
 import { Cauldron, Ladle, EmergencyBrake, Timelock } from '../../../typechain'
 import { revokeRoot } from '../permissions/revokeRoot'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 /**
  * @dev This script orchestrates the Ladle

--- a/scripts/fragments/core/orchestrateLadleToCauldron.ts
+++ b/scripts/fragments/core/orchestrateLadleToCauldron.ts
@@ -1,6 +1,5 @@
-import { id } from '@yield-protocol/utils-v2'
 import { Cauldron, Ladle, EmergencyBrake, Timelock } from '../../../typechain'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 /**
  * @dev This script orchestrates the Ladle

--- a/scripts/fragments/core/orchestrateWitch.ts
+++ b/scripts/fragments/core/orchestrateWitch.ts
@@ -2,11 +2,10 @@
  * @dev This script orchestrates Witch V2
  */
 
-import { id } from '@yield-protocol/utils-v2'
 import { ROOT } from '../../../shared/constants'
 import { EmergencyBrake, Timelock, Witch } from '../../../typechain'
 import { revokeRoot } from '../permissions/revokeRoot'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 export const orchestrateWitch = async (
   deployer: string,

--- a/scripts/fragments/core/orchestrateWitchToCauldron.ts
+++ b/scripts/fragments/core/orchestrateWitchToCauldron.ts
@@ -2,9 +2,8 @@
  * @dev This script orchestrates Witch V2
  */
 
-import { id } from '@yield-protocol/utils-v2'
-import { Cauldron, EmergencyBrake, Timelock, Witch } from '../../../typechain'
-import { indent } from '../../../shared/helpers'
+import { Cauldron, EmergencyBrake, Witch } from '../../../typechain'
+import { indent, id } from '../../../shared/helpers'
 
 export const orchestrateWitchToCauldron = async (
   cloak: EmergencyBrake,

--- a/scripts/fragments/emergency/drainJoinsFragment.ts
+++ b/scripts/fragments/emergency/drainJoinsFragment.ts
@@ -1,10 +1,9 @@
 /**
  * @dev This script transfers all tokens from a join to another
  */
-import { id } from '@yield-protocol/utils-v2'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { Join__factory, Timelock, Ladle } from '../../../typechain'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 export const drainJoinsFragment = async (
   ownerAcc: SignerWithAddress,

--- a/scripts/fragments/ladle/addFYToken.ts
+++ b/scripts/fragments/ladle/addFYToken.ts
@@ -2,10 +2,8 @@
  * @dev This script registers one fyToken with the ladle.
  */
 
-import { id } from '@yield-protocol/utils-v2'
 import { Ladle, FYToken, EmergencyBrake } from '../../../typechain'
-import { getName, indent } from '../../../shared/helpers'
-import { addToken } from './addToken'
+import { getName, indent, id } from '../../../shared/helpers'
 
 export const addFYToken = async (
   cloak: EmergencyBrake,

--- a/scripts/fragments/ladle/addJoin.ts
+++ b/scripts/fragments/ladle/addJoin.ts
@@ -2,9 +2,8 @@
  * @dev This script registers one join with the ladle.
  */
 
-import { id } from '@yield-protocol/utils-v2'
 import { Ladle, Join, EmergencyBrake } from '../../../typechain'
-import { getName, indent } from '../../../shared/helpers'
+import { getName, indent, id } from '../../../shared/helpers'
 
 export const addJoin = async (
   cloak: EmergencyBrake,

--- a/scripts/fragments/ladle/removeJoin.ts
+++ b/scripts/fragments/ladle/removeJoin.ts
@@ -2,10 +2,9 @@
  * @dev This script removes one or more joins with the ladle.
  */
 
-import { id } from '@yield-protocol/utils-v2'
 import { ZERO_ADDRESS } from '../../../shared/constants'
 import { Ladle, EmergencyBrake, Join__factory } from '../../../typechain'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 export const removeJoin = async (
   ownerAcc: any,

--- a/scripts/fragments/oracles/orchestrateAccumulatorOracle.ts
+++ b/scripts/fragments/oracles/orchestrateAccumulatorOracle.ts
@@ -1,8 +1,7 @@
-import { id } from '@yield-protocol/utils-v2'
 import { ROOT } from '../../../shared/constants'
 import { AccumulatorMultiOracle, EmergencyBrake, Timelock } from '../../../typechain'
 import { revokeRoot } from '../permissions/revokeRoot'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 /**
  * @dev This script permissions a AccumulatorMultiOracle

--- a/scripts/fragments/oracles/orchestrateChainlinkOracle.ts
+++ b/scripts/fragments/oracles/orchestrateChainlinkOracle.ts
@@ -1,8 +1,7 @@
-import { id } from '@yield-protocol/utils-v2'
 import { ROOT } from '../../../shared/constants'
 import { ChainlinkMultiOracle, EmergencyBrake, Timelock } from '../../../typechain'
 import { revokeRoot } from '../permissions/revokeRoot'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 /**
  * @dev This script permissions a ChainlinkMultiOracle

--- a/scripts/fragments/oracles/orchestrateChainlinkUSDOracle.ts
+++ b/scripts/fragments/oracles/orchestrateChainlinkUSDOracle.ts
@@ -1,8 +1,7 @@
-import { id } from '@yield-protocol/utils-v2'
 import { ROOT } from '../../../shared/constants'
 import { ChainlinkUSDMultiOracle, EmergencyBrake, Timelock } from '../../../typechain'
 import { revokeRoot } from '../permissions/revokeRoot'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 /**
  * @dev This script permissions a ChainlinkUSDMultiOracle

--- a/scripts/fragments/oracles/orchestrateCompositeOracle.ts
+++ b/scripts/fragments/oracles/orchestrateCompositeOracle.ts
@@ -1,9 +1,7 @@
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
-import { id } from '@yield-protocol/utils-v2'
 import { ROOT } from '../../../shared/constants'
 import { CompositeMultiOracle, EmergencyBrake, Timelock } from '../../../typechain'
 import { revokeRoot } from '../permissions/revokeRoot'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 /**
  * @dev This script permissions a CompositeMultiOracle

--- a/scripts/fragments/oracles/orchestrateCompoundOracle.ts
+++ b/scripts/fragments/oracles/orchestrateCompoundOracle.ts
@@ -1,8 +1,7 @@
-import { id } from '@yield-protocol/utils-v2'
 import { ROOT } from '../../../shared/constants'
 import { CompoundMultiOracle, EmergencyBrake, Timelock } from '../../../typechain'
 import { revokeRoot } from '../permissions/revokeRoot'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 /**
  * @dev This script permissions a CompoundMultiOracle

--- a/scripts/fragments/oracles/orchestrateCvx3CrvOracle.ts
+++ b/scripts/fragments/oracles/orchestrateCvx3CrvOracle.ts
@@ -1,8 +1,7 @@
-import { id } from '@yield-protocol/utils-v2'
 import { ROOT } from '../../../shared/constants'
 import { Timelock, EmergencyBrake, Cvx3CrvOracle } from '../../../typechain'
 import { revokeRoot } from '../permissions/revokeRoot'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 /**
  * @dev This script permissions the Cvx3CrvOracle

--- a/scripts/fragments/oracles/orchestrateLidoOracle.ts
+++ b/scripts/fragments/oracles/orchestrateLidoOracle.ts
@@ -1,8 +1,7 @@
-import { id } from '@yield-protocol/utils-v2'
 import { ROOT } from '../../../shared/constants'
 import { LidoOracle, EmergencyBrake, Timelock } from '../../../typechain'
 import { revokeRoot } from '../permissions/revokeRoot'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 /**
  * @dev This script permissions the LidoOracle

--- a/scripts/fragments/oracles/orchestrateNotionalOracle.ts
+++ b/scripts/fragments/oracles/orchestrateNotionalOracle.ts
@@ -1,8 +1,7 @@
-import { id } from '@yield-protocol/utils-v2'
 import { ROOT } from '../../../shared/constants'
 import { NotionalMultiOracle, EmergencyBrake, Timelock } from '../../../typechain'
 import { revokeRoot } from '../permissions/revokeRoot'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 /**
  * @dev This script permissions a NotionalMultiOracle

--- a/scripts/fragments/oracles/orchestrateStrategyOracle.ts
+++ b/scripts/fragments/oracles/orchestrateStrategyOracle.ts
@@ -1,10 +1,9 @@
-import { id } from '@yield-protocol/utils-v2'
 import { ROOT } from '../../../shared/constants'
 import { StrategyOracle } from '../../../typechain'
 import { EmergencyBrake } from '../../../typechain'
 import { Timelock } from '../../../typechain'
 import { revokeRoot } from '../permissions/revokeRoot'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 /**
  * @dev This script permissions the StrategyOracle

--- a/scripts/fragments/oracles/orchestrateUniswapOracle.ts
+++ b/scripts/fragments/oracles/orchestrateUniswapOracle.ts
@@ -1,8 +1,7 @@
-import { id } from '@yield-protocol/utils-v2'
 import { ROOT } from '../../../shared/constants'
 import { Timelock, EmergencyBrake, UniswapV3Oracle } from '../../../typechain'
 import { revokeRoot } from '../permissions/revokeRoot'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 /**
  * @dev This script permissions the UniswapV3Oracle

--- a/scripts/fragments/oracles/orchestrateYearnOracle.ts
+++ b/scripts/fragments/oracles/orchestrateYearnOracle.ts
@@ -1,8 +1,7 @@
-import { id } from '@yield-protocol/utils-v2'
 import { ROOT } from '../../../shared/constants'
 import { YearnVaultMultiOracle, EmergencyBrake, Timelock } from '../../../typechain'
 import { revokeRoot } from '../permissions/revokeRoot'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 /**
  * @dev This script permissions the YearnVaultMultiOracle

--- a/scripts/fragments/oracles/orchestrateYieldSpaceMultiOracle.ts
+++ b/scripts/fragments/oracles/orchestrateYieldSpaceMultiOracle.ts
@@ -1,8 +1,6 @@
-import { id } from '@yield-protocol/utils-v2'
-import { ROOT } from '../../../shared/constants'
 import { Timelock, YieldSpaceMultiOracle } from '../../../typechain'
 import { revokeRoot } from '../permissions/revokeRoot'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 /**
  * @dev This script permissions a YieldSpaceMultiOracle

--- a/scripts/fragments/other/notional/addNotionalJoin.ts
+++ b/scripts/fragments/other/notional/addNotionalJoin.ts
@@ -1,7 +1,6 @@
-import { id } from '@yield-protocol/utils-v2'
-import { getName, indent } from '../../../../shared/helpers'
 import { addJoin } from '../../ladle/addJoin'
 import { EmergencyBrake, Join__factory, Ladle, NotionalJoin } from '../../../../typechain'
+import { getName, indent, id } from '../../../../shared/helpers'
 
 export const addNotionalJoin = async (
   ownerAcc: any,

--- a/scripts/fragments/other/notional/orchestrateNotionalJoin.ts
+++ b/scripts/fragments/other/notional/orchestrateNotionalJoin.ts
@@ -1,8 +1,7 @@
-import { id } from '@yield-protocol/utils-v2'
 import { EmergencyBrake, Timelock, AccessControl__factory, NotionalJoin } from '../../../../typechain'
 import { revokeRoot } from '../../permissions/revokeRoot'
 import { addAsHostToCloak } from '../../cloak/addAsHostToCloak'
-import { indent } from '../../../../shared/helpers'
+import { indent, id } from '../../../../shared/helpers'
 
 export const orchestrateNotionalJoin = async (
   deployer: string,

--- a/scripts/fragments/permissions/grantDevelopers.ts
+++ b/scripts/fragments/permissions/grantDevelopers.ts
@@ -1,6 +1,5 @@
-import { id } from '@yield-protocol/utils-v2'
 import { Timelock, EmergencyBrake } from '../../../typechain'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 /**
  * @dev Grants developer permissions to an account.

--- a/scripts/fragments/permissions/grantGovernors.ts
+++ b/scripts/fragments/permissions/grantGovernors.ts
@@ -1,6 +1,5 @@
-import { id } from '@yield-protocol/utils-v2'
 import { Timelock, EmergencyBrake } from '../../../typechain'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 /**
  * @dev Grants governor permissions to an account.

--- a/scripts/fragments/permissions/revokeCloakExecute.ts
+++ b/scripts/fragments/permissions/revokeCloakExecute.ts
@@ -1,6 +1,5 @@
-import { id } from '@yield-protocol/utils-v2'
-import { Timelock, EmergencyBrake } from '../../../typechain'
-import { indent } from '../../../shared/helpers'
+import { EmergencyBrake } from '../../../typechain'
+import { indent, id } from '../../../shared/helpers'
 
 /**
  * @dev Revokes execute permissions on the cloak from an account.

--- a/scripts/fragments/permissions/revokeDevelopers.ts
+++ b/scripts/fragments/permissions/revokeDevelopers.ts
@@ -1,6 +1,5 @@
-import { id } from '@yield-protocol/utils-v2'
 import { Timelock, EmergencyBrake } from '../../../typechain'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 /**
  * @dev Revokes developer permissions from an account.

--- a/scripts/fragments/permissions/revokeGovernors.ts
+++ b/scripts/fragments/permissions/revokeGovernors.ts
@@ -1,6 +1,5 @@
-import { id } from '@yield-protocol/utils-v2'
 import { Timelock, EmergencyBrake } from '../../../typechain'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 /**
  * @dev Revokes governor permissions from an account.

--- a/scripts/fragments/pools/orchestratePool.ts
+++ b/scripts/fragments/pools/orchestratePool.ts
@@ -1,7 +1,6 @@
-import { id } from '@yield-protocol/utils-v2'
 import { Pool, Timelock, AccessControl__factory } from '../../../typechain'
 import { revokeRoot } from '../permissions/revokeRoot'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 /**
  * @dev This script orchestrates new pools

--- a/scripts/fragments/replace/replaceLadle.ts
+++ b/scripts/fragments/replace/replaceLadle.ts
@@ -1,8 +1,7 @@
 import { ethers, waffle } from 'hardhat'
 import * as hre from 'hardhat'
 import * as fs from 'fs'
-import { id } from '@yield-protocol/utils-v2'
-import { jsonToMap, getName } from '../../../shared/helpers'
+import { jsonToMap, getName, id } from '../../../shared/helpers'
 
 import { Ladle } from '../../../typechain/Ladle'
 import { Wand } from '../../../typechain/Wand'

--- a/scripts/fragments/replace/replaceWitch.ts
+++ b/scripts/fragments/replace/replaceWitch.ts
@@ -3,11 +3,10 @@
  */
 
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
-import { id } from '@yield-protocol/utils-v2'
 import { ethers } from 'hardhat'
 import { Cauldron, Ladle, Witch } from '../../../typechain'
 import { AuctionLineAndLimit } from '../../governance/confTypes'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 export const replaceWitch = async (
   ownerAcc: SignerWithAddress,

--- a/scripts/fragments/strategies/investStrategy.ts
+++ b/scripts/fragments/strategies/investStrategy.ts
@@ -3,10 +3,9 @@
  * @notice Make sure you define seriesToInvest in the strategy config.
  */
 
-import { id } from '@yield-protocol/utils-v2'
 import { Pool__factory, Strategy__factory } from '../../../typechain'
 import { Strategy } from '../../governance/confTypes'
-import { getName, indent } from '../../../shared/helpers'
+import { getName, indent, id } from '../../../shared/helpers'
 
 export const investStrategy = async (
   ownerAcc: any,

--- a/scripts/fragments/strategies/migrateStrategy.ts
+++ b/scripts/fragments/strategies/migrateStrategy.ts
@@ -1,12 +1,11 @@
 /**
  * @dev This script migrates strategies from v1 to v2.
  */
-import { id } from '@yield-protocol/utils-v2'
 import { ERC20__factory, Strategy__factory, StrategyV1__factory, Pool__factory } from '../../../typechain'
 import { MAX256 } from '../../../shared/constants'
 import { ethers } from 'hardhat'
 import { Strategy_V1 } from '../../governance/confTypes'
-import { indent, getName } from '../../../shared/helpers'
+import { indent, getName, id } from '../../../shared/helpers'
 
 export const migrateStrategy = async (
   ownerAcc: any,

--- a/scripts/fragments/strategies/orchestrateStrategy.ts
+++ b/scripts/fragments/strategies/orchestrateStrategy.ts
@@ -2,12 +2,10 @@
  * @dev This script orchestrates one or more strategies in the protocol.
  */
 
-import { id } from '@yield-protocol/utils-v2'
 import { Timelock, Ladle, AccessControl__factory, Strategy__factory } from '../../../typechain'
 import { Strategy } from '../../governance/confTypes'
 import { revokeRoot } from '../permissions/revokeRoot'
-import { getName, indent } from '../../../shared/helpers'
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { getName, indent, id } from '../../../shared/helpers'
 
 export const orchestrateStrategy = async (
   deployer: string,

--- a/scripts/fragments/utils/orchestrateCollateralWand.ts
+++ b/scripts/fragments/utils/orchestrateCollateralWand.ts
@@ -1,9 +1,9 @@
 import { ethers } from 'hardhat'
-import { id } from '@yield-protocol/utils-v2'
+
 import { ROOT } from '../../../shared/constants'
 import { Cauldron, ChainlinkMultiOracle, EmergencyBrake, Join, Ladle, Timelock, Witch } from '../../../typechain'
 import { CollateralWand } from '../../../typechain'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 const { protocol, governance } = require(process.env.CONF as string)
 export const orchestrateCollateralWand = async (

--- a/scripts/fragments/utils/orchestrateConvexWrapper.ts
+++ b/scripts/fragments/utils/orchestrateConvexWrapper.ts
@@ -1,7 +1,6 @@
-import { id } from '@yield-protocol/utils-v2'
 import { ROOT } from '../../../shared/constants'
 import { Timelock, EmergencyBrake, ConvexYieldWrapper } from '../../../typechain'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 /**
  * @dev This script permissions the ConvexYieldWrapper

--- a/scripts/fragments/utils/orchestrateFCashWand.ts
+++ b/scripts/fragments/utils/orchestrateFCashWand.ts
@@ -1,5 +1,4 @@
 import { ethers } from 'hardhat'
-import { id } from '@yield-protocol/utils-v2'
 import { ROOT } from '../../../shared/constants'
 import { readAddressMappingIfExists } from '../../../shared/helpers'
 import { Cauldron, NotionalMultiOracle, EmergencyBrake, Ladle, Timelock, OldWitch } from '../../../typechain'
@@ -8,7 +7,7 @@ import { developer } from '../../governance/base.arb_mainnet.config'
 const { protocol, governance } = require(process.env.CONF as string)
 const joins = readAddressMappingIfExists('joins.json')
 import { FDAI2212, FUSDC2212 } from '../../../shared/constants'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 export const orchestrateFCashWand = async (
   ownerAcc: any,

--- a/scripts/fragments/utils/orchestrateGiver.ts
+++ b/scripts/fragments/utils/orchestrateGiver.ts
@@ -1,7 +1,6 @@
 import { Cauldron, Giver, Timelock } from '../../../typechain'
-import { id } from '@yield-protocol/utils-v2'
 import { ROOT } from '../../../shared/constants'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 /**
  * @dev This script orchestrates the giver

--- a/scripts/fragments/utils/orchestrateLever.ts
+++ b/scripts/fragments/utils/orchestrateLever.ts
@@ -1,6 +1,5 @@
 import { Giver } from '../../../typechain'
-import { id } from '@yield-protocol/utils-v2'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 /**
  * @dev This script orchestrates the Lever

--- a/scripts/fragments/utils/orchestrateSeriesWand.ts
+++ b/scripts/fragments/utils/orchestrateSeriesWand.ts
@@ -1,9 +1,8 @@
 import { ethers } from 'hardhat'
-import { id } from '@yield-protocol/utils-v2'
 import { ROOT } from '../../../shared/constants'
 import { Cauldron, EmergencyBrake, Ladle, Timelock } from '../../../typechain'
 import { SeriesWand } from '../../../typechain'
-import { indent } from '../../../shared/helpers'
+import { indent, id } from '../../../shared/helpers'
 
 const { protocol, governance } = require(process.env.CONF as string)
 export const orchestrateSeriesWand = async (

--- a/scripts/fragments/witch/addBaseToWitch.ts
+++ b/scripts/fragments/witch/addBaseToWitch.ts
@@ -2,9 +2,8 @@
  * @dev This script registers one fyToken with the ladle.
  */
 
-import { id } from '@yield-protocol/utils-v2'
-import { getName, indent } from '../../../shared/helpers'
 import { Witch, Join, EmergencyBrake } from '../../../typechain'
+import { getName, indent, id } from '../../../shared/helpers'
 
 export const addBaseToWitch = async (
   cloak: EmergencyBrake,

--- a/scripts/fragments/witch/addFYTokenToWitch.ts
+++ b/scripts/fragments/witch/addFYTokenToWitch.ts
@@ -2,9 +2,8 @@
  * @dev This script registers one fyToken with the ladle.
  */
 
-import { id } from '@yield-protocol/utils-v2'
-import { getName, indent } from '../../../shared/helpers'
 import { Witch, FYToken, EmergencyBrake } from '../../../typechain'
+import { getName, indent, id } from '../../../shared/helpers'
 
 export const addFYTokenToWitch = async (
   cloak: EmergencyBrake,

--- a/scripts/fragments/witch/addIlkToWitch.ts
+++ b/scripts/fragments/witch/addIlkToWitch.ts
@@ -3,11 +3,10 @@
  * @notice Make sure you define auctionLineAndLimit in the ilk config.
  */
 
-import { id } from '@yield-protocol/utils-v2'
-import { getName, indent } from '../../../shared/helpers'
 import { Witch, Join, EmergencyBrake } from '../../../typechain'
 import { setLineAndLimit } from '../witch/setLineAndLimit'
 import { Ilk } from '../../governance/confTypes'
+import { getName, indent, id } from '../../../shared/helpers'
 
 export const addIlkToWitch = async (
   cloak: EmergencyBrake,

--- a/scripts/fragments/witch/orchestrateAuctionAssets.ts
+++ b/scripts/fragments/witch/orchestrateAuctionAssets.ts
@@ -3,10 +3,9 @@
  */
 
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
-import { id } from '@yield-protocol/utils-v2'
 import { ethers } from 'hardhat'
-import { getName, indent } from '../../../shared/helpers'
 import { Cauldron, Ladle, OldEmergencyBrake, Witch, Join__factory } from '../../../typechain'
+import { getName, indent, id } from '../../../shared/helpers'
 
 export const orchestrateAuctionAssets = async (
   ownerAcc: SignerWithAddress,

--- a/scripts/governance/add/addCollateral/addCompositeCollateral/convex/removeLadlePermissionsProposal.ts
+++ b/scripts/governance/add/addCollateral/addCompositeCollateral/convex/removeLadlePermissionsProposal.ts
@@ -1,6 +1,5 @@
-import { id } from '@yield-protocol/utils-v2'
-
 import { Cauldron, Ladle } from '../../../../../../typechain'
+import { id } from '../../../../../../shared/helpers'
 
 /**
  * @dev This script orchestrates the Ladle

--- a/scripts/governance/add/addUtilityContracts/wands/collateralWand_test.ts
+++ b/scripts/governance/add/addUtilityContracts/wands/collateralWand_test.ts
@@ -24,7 +24,7 @@ import ERC20MockArtifact from '../../../../../artifacts/contracts/::mocks/ERC20M
 import JoinArtifact from '../../../../../artifacts/@yield-protocol/vault-v2/contracts/Join.sol/Join.json'
 import ChainlinkAggregatorV3MockArtifact from '../../../../../artifacts/contracts/::mocks/ChainlinkAggregatorV3Mock.sol/ChainlinkAggregatorV3Mock.json'
 import { ChainlinkAggregatorV3Mock } from '../../../../../typechain'
-import { id } from '@yield-protocol/utils-v2'
+import { id } from '../../../../../shared/helpers'
 import { BigNumber } from 'ethers'
 
 describe('CollateralWand', function () {

--- a/scripts/governance/add/addUtilityContracts/wands/seriesWand_test.ts
+++ b/scripts/governance/add/addUtilityContracts/wands/seriesWand_test.ts
@@ -22,7 +22,7 @@ const { developer, whales } = require(process.env.CONF as string)
 const { protocol, governance } = require(process.env.CONF as string)
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { expect } from 'chai'
-import { id } from '@yield-protocol/utils-v2'
+import { id } from '../../../../../shared/helpers'
 import { BigNumber } from 'ethers'
 
 describe('Series Wand', function () {

--- a/scripts/governance/contango/shared/orchestrateContangoLadle.ts
+++ b/scripts/governance/contango/shared/orchestrateContangoLadle.ts
@@ -1,5 +1,5 @@
-import { id } from '@yield-protocol/utils-v2'
 import { ContangoLadle, OldEmergencyBrake } from '../../../../typechain'
+import { id } from '../../../../shared/helpers'
 
 export const orchestrateContangoLadle = async (
   contangoAddress: string,

--- a/scripts/governance/permissions/addDevelopers/addDevelopers.test.ts
+++ b/scripts/governance/permissions/addDevelopers/addDevelopers.test.ts
@@ -1,11 +1,11 @@
 import { ethers } from 'hardhat'
-import { id } from '@yield-protocol/utils-v2'
 import { newDevelopers, developerToImpersonate } from './addDevelopers.mainnet.config'
 import {
   readAddressMappingIfExists,
   getOwnerOrImpersonate,
   getOriginalChainId,
   impersonate,
+  id,
 } from '../../../../shared/helpers'
 import { WAD } from '../../../../shared/constants'
 import { Timelock, EmergencyBrake, PoolFactory, Wand } from '../../../../typechain'

--- a/scripts/governance/permissions/revokeDevelopers/revokeDevelopers.test.ts
+++ b/scripts/governance/permissions/revokeDevelopers/revokeDevelopers.test.ts
@@ -1,7 +1,6 @@
 import { ethers } from 'hardhat'
-import { id } from '@yield-protocol/utils-v2'
 import { revokeDevelopers, developer } from './revokeDevelopers.config'
-import { readAddressMappingIfExists, getOwnerOrImpersonate, impersonate } from '../../../../shared/helpers'
+import { readAddressMappingIfExists, getOwnerOrImpersonate, impersonate, id } from '../../../../shared/helpers'
 import { WAD } from '../../../../shared/constants'
 import { Timelock, EmergencyBrake } from '../../../../typechain'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'

--- a/shared/helpers.ts
+++ b/shared/helpers.ts
@@ -8,6 +8,15 @@ import { BaseProvider } from '@ethersproject/providers'
 import { Timelock } from '../typechain'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { DISPLAY_NAMES } from './constants'
+import { keccak256, toUtf8Bytes } from 'ethers/lib/utils'
+import { Interface } from '@ethersproject/abi'
+
+// --------- FUNCTION ENCODING ---------
+
+export const id = (abi: Interface, signature: string) => {
+  if (abi.functions[signature] === undefined) throw Error(`${signature} doesn't exist`)
+  return keccak256(toUtf8Bytes(signature)).slice(0, 10)
+}
 
 /// --------- PROPOSAL EXECUTION ---------
 

--- a/tools/vaultBuilt.ts
+++ b/tools/vaultBuilt.ts
@@ -6,8 +6,8 @@
 
 import { ethers } from 'hardhat'
 import * as fs from 'fs'
-import { id } from '@yield-protocol/utils-v2'
-import { jsonToMap } from '../../shared/helpers'
+
+import { jsonToMap, id } from '../../shared/helpers'
 
 import { Cauldron } from '../../typechain/Cauldron'
 import { Timelock } from '../../typechain/Timelock'


### PR DESCRIPTION
As part of the migration to submodules, we start by not importing the `id` function from yield-utils-v2 anymore. Now it belongs here in environments-v2.

This function just checks that a function exists in an interface, and we use it to make sure we don't give wrong permissions.